### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (18.04)
 
         * Note: other versions are likely to work but have not been tested.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
     - name: Debian
       versions:

--- a/molecule/ubuntu_min/molecule.yml
+++ b/molecule/ubuntu_min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible_role_bat_ubuntu_min
-    image: ubuntu:16.04
+    image: ubuntu:18.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
The latest bat package fails to install in Ubuntu Xenial.