### PR TITLE
Dropped support for Debian Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Requirements
 
         * Debian
 
-            * Jessie (8)
             * Stretch (9)
 
         * Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
         - focal
     - name: Debian
       versions:
-        - jessie
         - stretch
   galaxy_tags:
     - bat

--- a/molecule/debian_min/molecule.yml
+++ b/molecule/debian_min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible_role_bat_debian_min
-    image: debian:8
+    image: debian:9
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
The latest bat package fails to install in Debian Jessie.