### PR TITLE
all names should start with an uppercase letter

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: John Freeman
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.9
+  min_ansible_version: '2.9'
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: create download directory
+- name: Create download directory
   ansible.builtin.file:
     state: directory
     mode: 'u=rwx,go=rx'
     dest: '{{ bat_download_dir }}'
 
-- name: download bat
+- name: Download bat
   ansible.builtin.get_url:
     url: '{{ bat_redis_url }}'
     checksum: 'sha256:{{ bat_redis_sha256sum }}'
@@ -13,7 +13,7 @@
     force: no
     mode: 'u=rw,go=r'
 
-- name: install bat
+- name: Install bat
   become: yes
   ansible.builtin.apt:
     deb: '{{ bat_download_dir }}/{{ bat_redis_filename }}'


### PR DESCRIPTION
schema[meta]: 2.9 is not of type 'string' (warning) meta/main.yml:1  Returned errors will not include exact line numbers, but they will mention the schema name being used as a tag, like ``schema[playbook]``, ``schema[tasks]``.

This rule is not skippable and stops further processing of the file.

If incorrect schema was picked, you might want to either:

* move the file to standard location, so its file is detected correctly.
* use ``kinds:`` option in linter config to help it pick correct file type.

name[casing]: All names should start with an uppercase letter. (warning)
tasks/main.yml:2 Task/Handler: create download directory

name[casing]: All names should start with an uppercase letter. (warning)
tasks/main.yml:8 Task/Handler: download bat

name[casing]: All names should start with an uppercase letter. (warning)
tasks/main.yml:16 Task/Handler: install bat