### PR TITLE
remove unwated bat version to fix installation error

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: John Freeman
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.9
+  min_ansible_version: '2.9'
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: create download directory
+- name: Create download directory
   ansible.builtin.file:
     state: directory
     mode: 'u=rwx,go=rx'
     dest: '{{ bat_download_dir }}'
 
-- name: download bat
+- name: Download bat
   ansible.builtin.get_url:
     url: '{{ bat_redis_url }}'
     checksum: 'sha256:{{ bat_redis_sha256sum }}'
@@ -13,7 +13,7 @@
     force: no
     mode: 'u=rw,go=r'
 
-- name: install bat
+- name: Install bat
   become: yes
   ansible.builtin.apt:
     deb: '{{ bat_download_dir }}/{{ bat_redis_filename }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,5 +15,23 @@
 
 - name: Install bat
   become: yes
-  ansible.builtin.apt:
-    deb: '{{ bat_download_dir }}/{{ bat_redis_filename }}'
+  block:
+    - name: Install bat from local file
+      ansible.builtin.apt:
+        deb: '{{ bat_download_dir }}/{{ bat_redis_filename }}'
+        state: 'present'
+  rescue:
+    - name: Install xz-utils as deb requirements
+      ansible.builtin.apt:
+        package: 'xz-utils'
+        state: 'present'
+
+    - name: Make sure system is ready for selected bat version and remove bat
+      ansible.builtin.apt:
+        package: 'bat'
+        state: 'absent'
+
+    - name: Install remote
+      ansible.builtin.apt:
+        deb: '{{ bat_download_dir }}/{{ bat_redis_filename }}'
+        state: 'present'


### PR DESCRIPTION
On some of my hosts there was an issue with this role. See https://github.com/gantsign/ansible_role_bat/issues/62

The issue was, the installation of the package bat in version 0.12.1. Now we remove it once the installation fails.